### PR TITLE
add std::thread::native_handle_type get_running_thread();

### DIFF
--- a/src/CPPTimerPool/TimerPool.cpp
+++ b/src/CPPTimerPool/TimerPool.cpp
@@ -130,6 +130,10 @@ void TimerPool::unregisterTimer(TimerHandle timer)
     m_cond.notify_all();
 }
 
+std::thread::native_handle_type TimerPool::get_running_thread(){
+    return m_thread.native_handle();
+}
+
 void TimerPool::run()
 {
     std::vector<TimerHandle> expiredTimers;

--- a/src/CPPTimerPool/TimerPool.hpp
+++ b/src/CPPTimerPool/TimerPool.hpp
@@ -71,6 +71,8 @@ public:
     void                            registerTimer(TimerHandle timer);
     void                            unregisterTimer(TimerHandle timer);
 
+    std::thread::native_handle_type get_running_thread();
+
 protected:
     explicit                        TimerPool(const std::string& name);
 


### PR DESCRIPTION
as you said, return an std::thread::native_handle_type